### PR TITLE
Add flexible feature support

### DIFF
--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -531,6 +531,8 @@ class TileCircuit(generator.Generator):
         # placeholder for global signal wiring
         self.read_data_mux: MuxWithDefaultWrapper = None
 
+        self.finalized = False
+
     def __add_tile_id(self):
         self.add_port("tile_id",
                       magma.In(magma.Bits(self.tile_id_width)))
@@ -579,6 +581,9 @@ class TileCircuit(generator.Generator):
         return False
 
     def finalize(self):
+        if self.finalized:
+            return
+        self.finalized = True
         # add stall and reset signal
         self.__add_stall()
         self.__add_reset()

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -496,13 +496,10 @@ class TileCircuit(generator.Generator):
                         sb_circuit.wire(sb_circuit.ports[port_name],
                                         mux.ports.I[idx])
 
-        # add configuration space
-        # we can't use the InterconnectConfigurable because the tile class
-        # doesn't have any mux
         self.__add_tile_id()
-        self.__add_config()
-        self.__add_stall(stall_signal_width)
-        self.__add_reset()
+        # add ports
+        self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)),
+                       reset=magma.In(magma.AsyncReset))
 
         # lift ports if there is empty sb
         self.__lift_ports()
@@ -510,14 +507,37 @@ class TileCircuit(generator.Generator):
         # tile ID
         self.instance_name = f"Tile_X{self.x:02X}_Y{self.y:02X}"
 
+        # add features
+        self.__features: List[generator.Generator] = []
+        # users are free to add more features to the core
+
+        # add feature
+        if self.core is not None:
+            # add core features first
+            assert isinstance(self.core, Core)
+            for feature in self.core.features():
+                self.add_feature(feature)
+        # then CBs
+        cb_names = list(self.cbs.keys())
+        cb_names.sort()
+        for name in cb_names:
+            self.add_feature(self.cbs[name])
+        # then SBs
+        sb_widths = list(self.sbs.keys())
+        sb_widths.sort()
+        for width in sb_widths:
+            self.add_feature(self.sbs[width])
+
+        # placeholder for global signal wiring
+        self.read_data_mux: MuxWithDefaultWrapper = None
+
     def __add_tile_id(self):
         self.add_port("tile_id",
                       magma.In(magma.Bits(self.tile_id_width)))
 
-    def __add_stall(self, stall_signal_width: int):
+    def __add_stall(self):
         # automatically add stall signal and connect it to the features if the
         # feature supports it
-        self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
         stall_ports = []
         for feature in self.features():
             if "stall" in feature.ports.keys():
@@ -532,7 +552,6 @@ class TileCircuit(generator.Generator):
     def __add_reset(self):
         # automatically add reset signal and connect it to the features if the
         # feature supports it
-        self.add_ports(reset=magma.In(magma.AsyncReset))
         reset_ports = []
         for feature in self.features():
             if "reset" in feature.ports.keys():
@@ -559,7 +578,11 @@ class TileCircuit(generator.Generator):
                 assert "reset" not in feature.ports
         return False
 
-    def __add_config(self):
+    def finalize(self):
+        # add stall and reset signal
+        self.__add_stall()
+        self.__add_reset()
+
         # see if we really need to add config or not
         if not self.__should_add_config():
             return
@@ -594,25 +617,25 @@ class TileCircuit(generator.Generator):
         self.wire(self.read_data_mux.ports.O, self.ports.read_config_data)
 
         # Logic to generate EN input for read_data_mux
-        self.read_and_tile = FromMagma(mantle.DefineAnd(2))
-        self.eq_tile = FromMagma(mantle.DefineEQ(self.tile_id_width))
+        read_and_tile = FromMagma(mantle.DefineAnd(2))
+        eq_tile = FromMagma(mantle.DefineEQ(self.tile_id_width))
         # config_addr.tile_id == self.tile_id?
-        self.wire(self.ports.tile_id, self.eq_tile.ports.I0)
+        self.wire(self.ports.tile_id, eq_tile.ports.I0)
         self.wire(self.ports.config.config_addr[self.tile_id_slice],
-                  self.eq_tile.ports.I1)
+                  eq_tile.ports.I1)
         # (config_addr.tile_id == self.tile_id) & READ
-        self.wire(self.read_and_tile.ports.I0, self.eq_tile.ports.O)
-        self.wire(self.read_and_tile.ports.I1, self.ports.config.read[0])
+        self.wire(read_and_tile.ports.I0, eq_tile.ports.O)
+        self.wire(read_and_tile.ports.I1, self.ports.config.read[0])
         # read_data_mux.EN = (config_addr.tile_id == self.tile_id) & READ
-        self.wire(self.read_and_tile.ports.O, self.read_data_mux.ports.EN[0])
+        self.wire(read_and_tile.ports.O, self.read_data_mux.ports.EN[0])
 
         # Logic for writing to config registers
         # Config_en_tile = (config_addr.tile_id == self.tile_id & WRITE)
-        self.write_and_tile = FromMagma(mantle.DefineAnd(2))
-        self.wire(self.write_and_tile.ports.I0, self.eq_tile.ports.O)
-        self.wire(self.write_and_tile.ports.I1, self.ports.config.write[0])
-        self.decode_feat = []
-        self.feat_and_config_en_tile = []
+        write_and_tile = FromMagma(mantle.DefineAnd(2))
+        self.wire(write_and_tile.ports.I0, eq_tile.ports.O)
+        self.wire(write_and_tile.ports.I1, self.ports.config.write[0])
+        decode_feat = []
+        feat_and_config_en_tile = []
         for i, feat in enumerate(self.features()):
             # wire each feature's read_data output to
             # read_data_mux inputs
@@ -624,36 +647,30 @@ class TileCircuit(generator.Generator):
                 self.wire(Const(0), self.read_data_mux.ports.I[i])
             # for each feature,
             # config_en = (config_addr.feature == feature_num) & config_en_tile
-            self.decode_feat.append(
+            decode_feat.append(
                 FromMagma(mantle.DefineDecode(i, self.config_addr_width)))
-            self.decode_feat[-1].instance_name = f"DECODE_FEATURE_{i}"
-            self.feat_and_config_en_tile.append(FromMagma(mantle.DefineAnd(2)))
-            self.feat_and_config_en_tile[-1].instance_name = f"FEATURE_AND_{i}"
-            self.wire(self.decode_feat[i].ports.I,
+            decode_feat[-1].instance_name = f"DECODE_FEATURE_{i}"
+            feat_and_config_en_tile.append(FromMagma(mantle.DefineAnd(2)))
+            feat_and_config_en_tile[-1].instance_name = f"FEATURE_AND_{i}"
+            self.wire(decode_feat[i].ports.I,
                       self.ports.config.config_addr[self.feature_addr_slice])
-            self.wire(self.decode_feat[i].ports.O,
-                      self.feat_and_config_en_tile[i].ports.I0)
-            self.wire(self.write_and_tile.ports.O,
-                      self.feat_and_config_en_tile[i].ports.I1)
+            self.wire(decode_feat[i].ports.O,
+                      feat_and_config_en_tile[i].ports.I0)
+            self.wire(write_and_tile.ports.O,
+                      feat_and_config_en_tile[i].ports.I1)
             if "config" in feat.ports:
-                self.wire(self.feat_and_config_en_tile[i].ports.O,
+                self.wire(feat_and_config_en_tile[i].ports.O,
                           feat.ports.config.write[0])
             if "config_en" in feat.ports:
                 self.wire(feat.ports.config_en,
-                          self.feat_and_config_en_tile[i].ports.O)
+                          feat_and_config_en_tile[i].ports.O)
+
+    def add_feature(self, feature: generator.Generator):
+        assert isinstance(feature, generator.Generator)
+        self.__features.append(feature)
 
     def features(self) -> List[generator.Generator]:
-        cb_names = list(self.cbs.keys())
-        cb_names.sort()
-        cb_features = [self.cbs[name] for name in cb_names]
-        sb_widths = list(self.sbs.keys())
-        sb_widths.sort()
-        sb_features = [self.sbs[width] for width in sb_widths if
-                       self.sbs[width].switchbox.num_track > 0]
-        if self.core is None:
-            assert len(cb_features) == 0
-            return []
-        return self.core.features() + cb_features + sb_features
+        return self.__features
 
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         assert src_node.width == dst_node.width

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -582,7 +582,7 @@ class TileCircuit(generator.Generator):
 
     def finalize(self):
         if self.finalized:
-            return
+            raise Exception("Circuit already finalized")
         self.finalized = True
         # add stall and reset signal
         self.__add_stall()

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -310,7 +310,7 @@ class Interconnect(generator.Generator):
 
     def finalize(self):
         if self.finalized:
-            return
+            raise Exception("Circuit already finalized")
         self.finalized = True
         # finalize the design. after this, users are not able to add
         # features to the tiles any more

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -144,6 +144,8 @@ class Interconnect(generator.Generator):
         # set tile_id
         self.__set_tile_id()
 
+        self.finalized = False
+
     def __get_tile_id(self, x: int, y: int):
         return x << (self.tile_id_width // 2) | y
 
@@ -307,6 +309,9 @@ class Interconnect(generator.Generator):
                 self.ports.stall.qualified_name())
 
     def finalize(self):
+        if self.finalized:
+            return
+        self.finalized = True
         # finalize the design. after this, users are not able to add
         # features to the tiles any more
         # clean up first

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -306,6 +306,15 @@ class Interconnect(generator.Generator):
                 self.ports.reset.qualified_name(),
                 self.ports.stall.qualified_name())
 
+    def finalize(self):
+        # finalize the design. after this, users are not able to add
+        # features to the tiles any more
+        # clean up first
+        self.__cleanup_tiles()
+        # finalize individual tiles first
+        for _, tile in self.tile_circuits.items():
+            tile.finalize()
+
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         # this is the complete one which includes the tile_id
         x, y = dst_node.x, dst_node.y

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -234,6 +234,9 @@ def test_tile(num_tracks: int):
     tile_circuit = TileCircuit(tiles, addr_width, data_width,
                                tile_id_width=tile_id_width)
 
+    # finalize it
+    tile_circuit.finalize()
+
     circuit = tile_circuit.circuit()
 
     # set up the configuration and test data

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -85,6 +85,10 @@ def test_interconnect(num_tracks: int, chip_size: int,
 
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
                                 lift_ports=True)
+
+    # finalize the design
+    interconnect.finalize()
+
     # wiring
     if wiring == GlobalSignalWiring.Fanout:
         apply_global_fanout_wiring(interconnect)

--- a/tests/test_special_tiles.py
+++ b/tests/test_special_tiles.py
@@ -13,6 +13,7 @@ def test_empty_tile():
     tile = Tile(0, 0, bit_width, SwitchBox(0, 0, 0, bit_width, []))
     tile.set_core(core)
     tile_circuit = TileCircuit({bit_width: tile}, 8, 32)
+    tile_circuit.finalize()
     circuit = tile_circuit.circuit()
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, "tile")
@@ -31,6 +32,7 @@ def test_empty_switch_box():
     sb_node.add_edge(tile.ports["data_in_1b"])
 
     tile_circuit = TileCircuit({bit_width: tile}, 8, 32)
+    tile_circuit.finalize()
     # also need to ground the 16 bit
     tile_circuit.wire(Const(0), tile_circuit.core.ports["data_in_16b"])
     circuit = tile_circuit.circuit()
@@ -79,6 +81,7 @@ def test_empty_tile_util():
                                          margin=margin)
         ics[bit_width] = ic
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width)
+    interconnect.finalize()
     # wiring
     apply_global_meso_wiring(interconnect, margin=margin)
 


### PR DESCRIPTION
This PR removes hard-coded feature list in the tile level. It allows users to have multiple passes to add and remove core features at any time. One typical usage is power domain where power domain is configured as a tile feature and added at later time.

The only downside is that users have to call `finalize` to freeze the features. It is because `canal` will create the actual hardware to allocate feature space and mux the config data.